### PR TITLE
Use method modifiers instead of separate methods

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ Moo = 1.000008
 strictures = 1
 Hash::Util::FieldHash::Compat = 0
 Variable::Magic = 0.52
+Class::Method::Modifiers = 2.05
 
 ; -- test dependencies
 [Prereqs / TestRequires]

--- a/lib/Method/Generate/Accessor/Role/LvalueAttribute.pm
+++ b/lib/Method/Generate/Accessor/Role/LvalueAttribute.pm
@@ -5,71 +5,42 @@ use strictures 1;
 
 use Moo::Role;
 use Variable::Magic qw(wizard cast);
+use Class::Method::Modifiers qw(install_modifier);
+use Hash::Util::FieldHash::Compat qw(fieldhash);
 
-use Hash::Util::FieldHash::Compat;
-
-Hash::Util::FieldHash::Compat::fieldhash my %LVALUES;
-
-require MooX::LvalueAttribute;
-
-around generate_method => sub {
-    my $orig = shift;
+after generate_method => sub {
     my $self = shift;
-    # would like a better way to disable XS
-
     my ($into, $name, $spec, $quote_opts) = @_;
 
-    $MooX::LvalueAttribute::INJECTED_IN_ROLE{$into}
-      || $MooX::LvalueAttribute::INJECTED_IN_CLASS{$into}
-      or return $self->$orig(@_);
+    return if !$spec->{lvalue};
 
-    if ($spec->{lvalue}) {
+    my $reader = $spec->{reader} || $spec->{accessor}
+        or die "lvalue was set but no accessor nor reader";
+    my $writer = $spec->{writer} || $spec->{accessor}
+        or die "lvalue was set but no accessor nor writer";
 
-        my $is = $spec->{is};
-        if ($is eq 'rw') {
-            $spec->{accessor} = $name unless exists $spec->{accessor}
-              or ( $spec->{reader} and $spec->{writer} );
-        } elsif ($is eq 'rwp') {
-            $spec->{writer} = "_set_${name}" unless exists $spec->{writer};
-        }
+    my $read_code = $into->can($reader);
+    my $write_code = $into->can($writer);
 
-        exists $spec->{writer} || exists $spec->{accessor}
-          or die "lvalue was set but no accessor nor reader, and attribute is not rw";
-        foreach( qw(writer accessor) ) {
-            my $t = $spec->{$_}
-              or next;
-            $spec->{'lv_' . $_} = $t;
-            $spec->{$_} = '_lv_' . $t;
-        }
-    }
+    my $wiz = wizard(
+        data => sub { $_[1] },
+        get  => sub { ${$_[0]} = $_[1]->$read_code; 1 },
+        set  => sub { $_[1]->$write_code(${$_[0]}); 1 },
+    );
 
-    my $methods = $self->$orig(@_);
-
-    foreach ( qw(writer accessor) ) {
-        my $lv_name = $spec->{'lv_' . $_}
-          or next;
-        my $name = $spec->{$_};
-        no strict 'refs';
-        my $sub = sub : lvalue {
+    fieldhash my %cast;
+    for my $method (grep defined, map $spec->{$_}, qw(writer accessor)) {
+        install_modifier($into, 'around', $method, sub :lvalue {
+            my $orig = shift;
             my $self = shift;
-            if (! exists $LVALUES{$self}{$lv_name}) {
-                my $wiz = wizard(
-                 set  => sub {
-                     $self->$name(${$_[0]});
-                     return 1;
-                 },
-                 get => sub {
-                     ${$_[0]} = $self->$name();
-                     return 1;
-                 },
-                );
-                cast $LVALUES{$self}{$lv_name}, $wiz;
+            my $val;
+            $val = $self->$orig(@_)
+                if @_;
+            if (!exists $cast{$self}) {
+                cast $cast{$self}, $wiz, $self;
             }
-            @_ and $self->$name(@_);
-            $LVALUES{$self}{$lv_name};
-        };
-        $methods->{$lv_name} = $sub;
-        *{"${into}::${lv_name}"} = $sub;
+            $cast{$self};
+        });
     }
 };
 

--- a/t/lvalue.t
+++ b/t/lvalue.t
@@ -12,7 +12,7 @@ eval {
                );
 };
 
-like $@, qr/lvalue was set but no accessor nor reader/, "can't set an lvalue on a ro attribute";
+like $@, qr/lvalue was set but no accessor nor writer/, "can't set an lvalue on a ro attribute";
 
 {
     package MooLvalue;
@@ -50,11 +50,9 @@ is $lvalue->two, 43, "normal setter still works";
 
 $lvalue->two = 42;
 is $lvalue->two, 42, "lvalue set works";
-is $lvalue->_lv_two(), 42, "underlying getter works";
 
 $lvalue->three = 3;
 is $lvalue->three, 3, "lvalue set works for a second attribute";
-is $lvalue->_lv_three(), 3, "underlying getter works for a second attribute";
 
 eval { $lvalue->four = 4; };
 like $@, qr/Can't modify non-lvalue subroutine|Modification of a read-only value attempted/, "an attribute without lvalue";

--- a/t/lvalue_extend.t
+++ b/t/lvalue_extend.t
@@ -1,0 +1,88 @@
+use strictures 1;
+use Test::More;
+
+eval q{
+  package MooLvalue;
+  use Moo;
+  use MooX::LvalueAttribute;
+
+  has one => (
+    is => 'rw',
+    lvalue => 1,
+  );
+  $INC{'MooLvalue.pm'} = __FILE__;
+};
+is $@, '', 'define class with lvalue works';
+
+eval q{
+  package MooExtendLvalue;
+  use Moo;
+  extends 'MooLvalue';
+  has '+one' => (
+    required => 1,
+  );
+  $INC{'MooExtendLvalue.pm'} = __FILE__;
+};
+is $@, '', 'can extend lvalue attribute';
+
+my $extendlvalue = MooExtendLvalue->new(one => 1);
+eval { $extendlvalue->one = 5 };
+is $@, '', 'extended attribute still lvalue';
+
+eval q{
+  package MooClass;
+  use Moo;
+  has 'one' => (
+    is => 'rw',
+    required => 1,
+  );
+  $INC{'MooClass.pm'} = __FILE__;
+};
+is $@, '', 'define normal class';
+
+eval q{
+  package MooClassAddLvalue;
+  use Moo;
+  use MooX::LvalueAttribute;
+  extends 'MooClass';
+  has '+one' => (
+    lvalue => 1,
+  );
+  $INC{'MooClassAddLvalue.pm'} = __FILE__;
+};
+is $@, '', 'extend normal class, adding lvalue';
+
+my $addlvalue = MooClassAddLvalue->new(one => 1);
+eval { $addlvalue->one = 5 };
+is $@, '', 'added lvalue works';
+
+SKIP: {
+  local $TODO = 'lvalue not supported in role when extending attributes';
+  eval q{
+    package MooRoleAddLvalue;
+    use Moo::Role;
+    use MooX::LvalueAttribute;
+    has '+one' => (
+      lvalue => 1,
+    );
+    $INC{'MooRoleAddLvalue.pm'} = __FILE__;
+  };
+  is $@, '', 'define role to add lvalue'
+    or skip "can't test role when not defined", 2;
+
+  eval q{
+    package MooClassAddLvalueRole;
+    use Moo;
+    extends 'MooClass';
+    with 'MooRoleAddLvalue';
+
+    $INC{'MooClassAddLvalueRole.pm'} = __FILE__;
+  };
+  is $@, '', 'apply role adding lvalue';
+
+  my $addlvaluerole = MooClassAddLvalueRole->new(one => 1);
+  eval { $addlvalue->one = 5 };
+  is $@, '', 'added lvalue via role works';
+}
+
+done_testing;

--- a/t/lvalue_extend.t
+++ b/t/lvalue_extend.t
@@ -56,33 +56,4 @@ my $addlvalue = MooClassAddLvalue->new(one => 1);
 eval { $addlvalue->one = 5 };
 is $@, '', 'added lvalue works';
 
-SKIP: {
-  local $TODO = 'lvalue not supported in role when extending attributes';
-  eval q{
-    package MooRoleAddLvalue;
-    use Moo::Role;
-    use MooX::LvalueAttribute;
-    has '+one' => (
-      lvalue => 1,
-    );
-    $INC{'MooRoleAddLvalue.pm'} = __FILE__;
-  };
-  is $@, '', 'define role to add lvalue'
-    or skip "can't test role when not defined", 2;
-
-  eval q{
-    package MooClassAddLvalueRole;
-    use Moo;
-    extends 'MooClass';
-    with 'MooRoleAddLvalue';
-
-    $INC{'MooClassAddLvalueRole.pm'} = __FILE__;
-  };
-  is $@, '', 'apply role adding lvalue';
-
-  my $addlvaluerole = MooClassAddLvalueRole->new(one => 1);
-  eval { $addlvalue->one = 5 };
-  is $@, '', 'added lvalue via role works';
-}
-
 done_testing;

--- a/t/lvalue_in_role.t
+++ b/t/lvalue_in_role.t
@@ -58,11 +58,9 @@ is $lvalue->two, 43, "normal setter still works";
 
 $lvalue->two = 42;
 is $lvalue->two, 42, "lvalue set works, defined in a role";
-is $lvalue->_lv_two(), 42, "underlying getter works";
 
 $lvalue->three = 3;
 is $lvalue->three, 3, "lvalue set works for a second attribute";
-is $lvalue->_lv_three(), 3, "underlying getter works for a second attribute";
 
 eval { $lvalue->four = 42 };
 like $@, qr/Can't modify non-lvalue subroutine/, "this attr has no lvalue";
@@ -75,5 +73,11 @@ eval { $lvalue3->two = 42 };
 like $@, qr/Can't modify non-lvalue subroutine/, "a class without lvalue - first attribute";
 eval { $lvalue3->four = 42 };
 like $@, qr/Can't modify non-lvalue subroutine/, "a class without lvalue - second attribute";
+
+my $val = MooLvalue->new( two => 'explicit value', four => 'welp' );
+eval { my $f = sprintf('%s', $val->two) };
+is $@, '', 'lvalue attr from role works in sprintf';
+eval { my $f = sprintf('%s', $val->four) };
+is $@, '', 'lvalue attr from class works in sprintf';
 
 done_testing;

--- a/t/lvalue_in_role_with_xs.t
+++ b/t/lvalue_in_role_with_xs.t
@@ -61,22 +61,11 @@ is $lvalue->two, 43, "normal setter still works";
 
 $lvalue->two = 42;
 is $lvalue->two, 42, "lvalue set works, defined in a role";
-is $lvalue->_lv_two(), 42, "underlying getter works";
 
 $lvalue->three = 3;
 is $lvalue->three, 3, "lvalue set works for a second attribute";
-is $lvalue->_lv_three(), 3, "underlying getter works for a second attribute";
-
-eval { $lvalue->_lv_four() };
-like $@, qr/Can't locate object method "_lv_four"/, "this attr has no lvalue";
 
 my $lvalue2 = MooLvalue->new(two => 7);
 is $lvalue2->two, 7, "different instances have different values";
-
-my $lvalue3 = MooNoLvalue->new(two => 7, four => 8);
-eval { $lvalue3->_lv_two() };
-like $@, qr/Can't locate object method "_lv_two"/, "a class without lvalue - first attribute";
-eval { $lvalue3->_lv_four() };
-like $@, qr/Can't locate object method "_lv_four"/, "a class without lvalue - second attribute";
 
 done_testing;


### PR DESCRIPTION
This uses method modifiers to make accessors lvalue instead of installing extra methods to wrap.  This simplifies the code a bit.  It also includes some extra tests.
